### PR TITLE
Fix issue #32 ( https://github.com/oncleben31/ha-pool_pump/issues/32 )

### DIFF
--- a/src/pypool_pump/__init__.py
+++ b/src/pypool_pump/__init__.py
@@ -42,6 +42,15 @@ class FilteringDuration(object):
         second_start = pivot_time + timedelta(hours=2/3 * self._schedule_config['break_duration'])
         second_duration = 2 * first_duration
 
+        # If second_start + second_duration > 0h00 : update first_start with (second_start + second_duration - 0h00)
+        if second_start + timedelta(hours=second_duration) >= datetime.combine(second_start, datetime.max.time(), second_start.tzinfo):
+            delta = second_start + timedelta(hours=second_duration) - datetime.combine(second_start + timedelta(hours=second_duration), datetime.min.time(), second_start.tzinfo)
+            # First start need to be earlier
+            first_start = first_start - delta
+            # TODO: Update first_duration
+            first_duration = int( (pivot_time - first_start).total_seconds() ) / 3600
+            # TODO: Update second_duration
+            second_duration = int( ( datetime.combine(second_start, datetime.max.time(), second_start.tzinfo) - pivot_time ).total_seconds() ) / 3600
         return [Run(first_start, first_duration), Run(second_start, second_duration)]
 
 

--- a/src/pypool_pump/__init__.py
+++ b/src/pypool_pump/__init__.py
@@ -47,9 +47,9 @@ class FilteringDuration(object):
             delta = second_start + timedelta(hours=second_duration) - datetime.combine(second_start + timedelta(hours=second_duration), datetime.min.time(), second_start.tzinfo)
             # First start need to be earlier
             first_start = first_start - delta
-            # TODO: Update first_duration
+            # Update first_duration
             first_duration = int( (pivot_time - first_start).total_seconds() ) / 3600
-            # TODO: Update second_duration
+            # Update second_duration
             second_duration = int( ( datetime.combine(second_start, datetime.max.time(), second_start.tzinfo) - pivot_time ).total_seconds() ) / 3600
         return [Run(first_start, first_duration), Run(second_start, second_duration)]
 


### PR DESCRIPTION
Fixing issue #32 [Bug for Filtration time, impossible to use more than ~17h](https://github.com/oncleben31/ha-pool_pump/issues/32)

Tested with `input_number.pool_water_temperature : 32`

Log output of the custom_compoment ( splitting to several ligne for better visibility here ) 
```
Sep 27 14:56:25 pi hass[286052]: 2023-09-27 14:56:25.659 DEBUG (MainThread) [custom_components.pool_pump] Manager initialised: <PoolPumpManager(runs=[
<Run(
  start=2023-09-27 00:09:28.908000+02:00,
  stop=2023-09-27 13:27:59.908000+02:00,
   duration=13.30861111111111)>, 
<Run(
  start=2023-09-27 13:28:00+02:00,
  stop=2023-09-27 23:59:59+02:00,
  duration=10.533055555555556)>])>
```

Of course `first_duration = self._total_duration / 3` and `second_duration = 2 * first_duration` can't be used on these high level of temperature